### PR TITLE
Use server-wide allow-transfer setting for created zone on slave server

### DIFF
--- a/plib/library/Rndc.php
+++ b/plib/library/Rndc.php
@@ -41,7 +41,8 @@ class Modules_SlaveDnsManager_Rndc
         $slaves = null === $slave ? Modules_SlaveDnsManager_Slave::getList() : [$slave];
         foreach ($slaves as $slave) {
             $this->_call($slave, "addzone \"{$domain}\" \"{$slave->getRndcClass()}\" \"{$slave->getRndcView()}\"" .
-                " \"{ type slave; file \\\"{$domain}\\\"; masters { {$slave->getMasterPublicIp()}; }; };\"");
+                " \"{ type slave; file \\\"{$domain}\\\"; masters { {$slave->getMasterPublicIp()}; }; " .
+                "allow-transfer { common-allow-transfer; }; };\"");
         }
     }
 


### PR DESCRIPTION
allow-transfer defines a list of IP addresses that are allowed to transfer the zone information from server. The default behavior is to allow zone transfers to any host. Even if server wide setting is set to 
acl common-allow-transfer {
        none;
};
It will be overwritten by zone file.
So, adding common-allow-transfer option will prevent transferring zone file from slave server with such setting set to none.