### PR TITLE
Add flag "-clean" to "rndc delzone" for BIND v9.10+

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
+# 1.9.1 (12 Apr 2018)
+* [+] If slave DNS server supports flag "-clean" (BIND v9.10+), it will be added automatically for 'rndc delzone'
+
 # 1.9.0 (29 May 2017)
 * [-] Fixed an issue with IP-address if Plesk behind NAT (issue [#20](https://github.com/plesk/ext-slave-dns-manager/issues/20))
-* [-] 'Resync' button hidden in Plesk 12.5 and earlier
+* [-] 'Resync' button hidden in Plesk 12.5 and earlier because required API not supported
 
 # 1.8 (10 April 2017)
 * [+] Add support choose server's IP (issue [#13](https://github.com/plesk/ext-slave-dns-manager/issues/13))

--- a/meta.xml
+++ b/meta.xml
@@ -5,8 +5,8 @@
 	<name>Slave DNS Manager</name>
 	<description>The extension for managing a remote slave DNS server via rndc protocol (bind).</description>
 	<category>dns</category>
-	<version>1.9.0</version>
-	<release>2</release>
+	<version>1.9.1</version>
+	<release>0</release>
 	<vendor>Plesk</vendor>
 	<url>https://github.com/plesk/ext-slave-dns-manager</url>
 	<plesk_min_version>12.0.18</plesk_min_version>

--- a/plib/library/Rndc.php
+++ b/plib/library/Rndc.php
@@ -60,7 +60,12 @@ class Modules_SlaveDnsManager_Rndc
     {
         $slaves = null === $slave ? Modules_SlaveDnsManager_Slave::getList() : [$slave];
         foreach ($slaves as $slave) {
-            $this->_call($slave, "delzone \"{$domain}\" \"{$slave->getRndcClass()}\" \"{$slave->getRndcView()}\"");
+            $slaveStatus = $this->checkStatus($slave);
+            // version: 9.9.4-RedHat-9.9.4-51.el7_4.2 (none) <id:8f9657aa>
+            // version: BIND 9.10.3-P4-Ubuntu <id:ebd72b3> (none)
+            $cleanFlag = (preg_match("/version: (BIND )?(9\.10\.\d+|9\.11\.\d+|9\.12\.\d+)/", $slaveStatus)) ? "-clean" : ""; 
+
+            $this->_call($slave, "delzone $cleanFlag \"{$domain}\" \"{$slave->getRndcClass()}\" \"{$slave->getRndcView()}\"");
         }
     }
 


### PR DESCRIPTION
Since BIND v9.10, DNS server supports option "-clean" with command "delzone".

> **delzone [-clean] zone [class [view]]**
> Delete a zone while the server is running. Only zones that were originally added via rndc addzone can be deleted in this manner.

> If the -clean is specified, the zone's master file (and journal file, if any) will be deleted along with the zone. Without the -clean option, zone files must be cleaned up by hand. (If the zone is of type "slave" or "stub", the files needing to be cleaned up will be reported in the output of the rndc delzone command.)

(c) [manual page for rndc](https://ftp.isc.org/isc/bind9/cur/9.10/doc/arm/man.rndc.html)