### PR TITLE
Add support for multiple Views

### DIFF
--- a/plib/library/Form/Add.php
+++ b/plib/library/Form/Add.php
@@ -56,7 +56,7 @@ class Modules_SlaveDnsManager_Form_Add extends pm_Form_Simple
             'value' => '',
             'required' => false,
             'validators' => array(
-                array('Callback', true, array(array($this, 'isValidAlnumDashUnderscore'))),
+                array('Callback', true, array(array($this, 'isValidAlnumDashUnderscoreSemicol'))),
             ),
         ));
 
@@ -89,9 +89,9 @@ class Modules_SlaveDnsManager_Form_Add extends pm_Form_Simple
         throw new pm_Exception($this->lmsg('invalidSecret'));
     }
 
-    public function isValidAlnumDashUnderscore($data)
+    public function isValidAlnumDashUnderscoreSemicol($data)
     {
-        if (preg_match('/^[a-zA-Z0-9_-]+$/', $data)) {
+        if (preg_match('/^[;a-zA-Z0-9_-]+$/', $data)) {
             return true;
         }
         throw new pm_Exception($this->lmsg('invalidAlnumDashUnderscore'));

--- a/plib/library/Rndc.php
+++ b/plib/library/Rndc.php
@@ -11,8 +11,8 @@ class Modules_SlaveDnsManager_Rndc
             "-y \"{$slave->getRndcKeyId()}\"",
             "-c \"{$slave->getConfigPath()}\"",
             $arguments,
-        ]);
-
+            ]);
+        
         if (pm_ProductInfo::isWindows()) {
             $command = '"' . PRODUCT_ROOT . '\dns\bin\rndc.exe"';
         } else {
@@ -20,42 +20,48 @@ class Modules_SlaveDnsManager_Rndc
         }
         exec("{$command} {$arguments} 2>&1", $out, $code);
         $output = implode("\n", $out);
-
+        
         if ($verbose) {
             if ($code != 0) {
                 throw new pm_Exception("$command $arguments\n$output\n\nError code: $code");
             }
             return $output;
         }
-
+        
         if ($code != 0) {
             // Cannot send output header due to possible API-RPC calls
             error_log("Error code $code: $output");
         }
-
+        
         return $code == 0;
     }
-
+    
     public function addZone($domain, Modules_SlaveDnsManager_Slave $slave = null)
     {
         $slaves = null === $slave ? Modules_SlaveDnsManager_Slave::getList() : [$slave];
         foreach ($slaves as $slave) {
-            $this->_call($slave, "addzone \"{$domain}\" \"{$slave->getRndcClass()}\" \"{$slave->getRndcView()}\"" .
+            $multiView = $this->multipleView($slave->getRndcView());
+            foreach ($multiView as $view) {
+                $this->_call($slave, "addzone \"{$domain}\" \"{$slave->getRndcClass()}\" \"{$view}\"" .
                 " \"{ type slave; file \\\"{$domain}\\\"; masters { {$slave->getMasterPublicIp()}; }; };\"");
+            }
         }
     }
-
+    
     public function updateZone($domain, Modules_SlaveDnsManager_Slave $slave = null)
     {
         $slaves = null === $slave ? Modules_SlaveDnsManager_Slave::getList() : [$slave];
         foreach ($slaves as $slave) {
-            $result = $this->_call($slave, "refresh \"{$domain}\" \"{$slave->getRndcClass()}\" \"{$slave->getRndcView()}\"");
-            if (false === $result) {
-                $this->addZone($domain, $slave);
+            $multiView = $this->multipleView($slave->getRndcView());
+            foreach ($multiView as $view) {
+                $result = $this->_call($slave, "refresh \"{$domain}\" \"{$slave->getRndcClass()}\" \"{$view}\"");
+                if (false === $result) {
+                    $this->addZone($domain, $slave);
+                }
             }
         }
     }
-
+    
     public function deleteZone($domain, Modules_SlaveDnsManager_Slave $slave = null)
     {
         $slaves = null === $slave ? Modules_SlaveDnsManager_Slave::getList() : [$slave];
@@ -63,14 +69,27 @@ class Modules_SlaveDnsManager_Rndc
             $slaveStatus = $this->checkStatus($slave);
             // version: 9.9.4-RedHat-9.9.4-51.el7_4.2 (none) <id:8f9657aa>
             // version: BIND 9.10.3-P4-Ubuntu <id:ebd72b3> (none)
-            $cleanFlag = (preg_match("/version: (BIND )?(9\.10\.\d+|9\.11\.\d+|9\.12\.\d+)/", $slaveStatus)) ? "-clean" : ""; 
-
-            $this->_call($slave, "delzone $cleanFlag \"{$domain}\" \"{$slave->getRndcClass()}\" \"{$slave->getRndcView()}\"");
+            $cleanFlag = (preg_match("/version: (BIND )?(9\.10\.\d+|9\.11\.\d+|9\.12\.\d+)/", $slaveStatus)) ? "-clean" : "";
+            
+            $multiView = $this->multipleView($slave->getRndcView());
+            foreach ($multiView as $view) {
+                $this->_call($slave, "delzone $cleanFlag \"{$domain}\" \"{$slave->getRndcClass()}\" \"{$view}\"");
+            }
         }
     }
-
+    
     public function checkStatus(Modules_SlaveDnsManager_Slave $slave)
     {
         return $this->_call($slave, "status", true);
+    }
+    
+    public function multipleView($view)
+    {
+        if(strpos($view, ';')!==false){
+            $multiView = explode(';', $view);
+            if(!is_array($multiView)) throw new pm_Exception("Multi-Views Error, Views given: $view");
+        } else $multiView[] = $view;
+        
+        return $multiView;
     }
 }


### PR DESCRIPTION
Adding support for multiple Views. Seperate multiple Views with Semicolon. (view1;view2;view3)
https://github.com/plesk/ext-slave-dns-manager/issues/32