### PR TITLE
Added support for the HMAC-SHA256 algorithm

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 1.10.4 (01 March 2025)
+
+* [+] Added support for the HMAC-SHA256 algorithm, which is now the new default option.
+
 # 1.10.3 (12 October 2023)
 
 * [*] Internal improvements.

--- a/meta.xml
+++ b/meta.xml
@@ -5,7 +5,7 @@
 	<name>Slave DNS Manager</name>
 	<description>The extension for managing a remote slave DNS server via rndc protocol (bind).</description>
 	<category>dns</category>
-	<version>1.10.3</version>
+	<version>1.10.4</version>
 	<release>0</release>
 	<vendor>Plesk</vendor>
 	<url>https://github.com/plesk/ext-slave-dns-manager</url>

--- a/plib/library/ApiRpc/DnsSlave/AddCommand.php
+++ b/plib/library/ApiRpc/DnsSlave/AddCommand.php
@@ -9,8 +9,8 @@ use Modules_SlaveDnsManager_Slave;
 
 class AddCommand extends AbstractCommand
 {
-    const AVAILABLE_ALGORITHMS = ['hmac-md5'];
-    const DEFAULT_ALGORITHM = 'hmac-md5';
+    const AVAILABLE_ALGORITHMS = ['hmac-sha256', 'hmac-md5'];
+    const DEFAULT_ALGORITHM = 'hmac-sha256';
     const DEFAULT_PORT = 953;
 
     protected function _checkParams()

--- a/plib/library/Form/Add.php
+++ b/plib/library/Form/Add.php
@@ -37,8 +37,8 @@ class Modules_SlaveDnsManager_Form_Add extends pm_Form_Simple
         ));
         $this->addElement('select', 'algorithm', array(
             'label' => $this->lmsg('algorithmLabel'),
-            'multiOptions' => array('hmac-md5' => 'hmac-md5',),
-            'value' => 'hmac-md5',
+            'multiOptions' => array('hmac-sha256' => 'hmac-sha256', 'hmac-md5' => 'hmac-md5',),
+            'value' => 'hmac-sha256',
             'required' => true,
         ));
         $this->addElement('text', 'secret', array(

--- a/plib/library/Slave.php
+++ b/plib/library/Slave.php
@@ -105,7 +105,7 @@ class Modules_SlaveDnsManager_Slave
             }
         }
 
-        $keyAlgorithm = array_key_exists('algorithm', $data) ? $data['algorithm'] : 'hmac-md5';
+        $keyAlgorithm = array_key_exists('algorithm', $data) ? $data['algorithm'] : 'hmac-sha256';
         $keySecret = $data['secret'];
 
         $this->_saveConfig($this->getConfigPath(), $this->_renderConfig($slaveIp, $keySecret, $keyAlgorithm));
@@ -121,7 +121,7 @@ class Modules_SlaveDnsManager_Slave
 
         $view = new Zend_View();
         $view->setScriptPath(pm_Context::getPlibDir() . 'views/scripts');
-        $slaveConfiguration = $view->partial('index/slave-config.phtml', ['masterPublicIp' => $masterPublicIp, 'secret' => $keySecret]);
+        $slaveConfiguration = $view->partial('index/slave-config.phtml', ['masterPublicIp' => $masterPublicIp, 'secret' => $keySecret, 'algorithm' => $keyAlgorithm]);
         $slaveConfiguration = trim(html_entity_decode(strip_tags($slaveConfiguration)));
         $slaveConfiguration = preg_replace('/^/m', '    ', $slaveConfiguration);
 

--- a/plib/views/scripts/index/add.phtml
+++ b/plib/views/scripts/index/add.phtml
@@ -3,29 +3,43 @@
 ?>
 <script type="text/javascript">
     Jsw.onReady(function () {
-        var select = document.getElementById('<?=$this->form->getElement('masterIp')->getId()?>');
+        var selectMasterPublicIp = document.getElementById('<?=$this->form->getElement('masterIp')->getId()?>');
+        var selectAlgorithm = document.getElementById('<?=$this->form->getElement('algorithm')->getId()?>');
 
         function updateMasterPublicIp() {
-            var value = select.options[select.selectedIndex].text;
+            var value = selectMasterPublicIp.options[selectMasterPublicIp.selectedIndex].text;
             var placeholders = document.getElementsByClassName('js-placeholder-ip');
             for (var i = 0; i < placeholders.length; i++) {
                 placeholders[i].innerHTML = value;
             }
         }
-        select.addEventListener('change', updateMasterPublicIp);
+
+        function updateAlgorithm() {
+            var value = selectAlgorithm.options[selectAlgorithm.selectedIndex].text;
+            var placeholders = document.getElementsByClassName('js-placeholder-algorithm');
+            for (var i = 0; i < placeholders.length; i++) {
+                placeholders[i].innerHTML = value;
+            }
+        }
+
+        selectMasterPublicIp.addEventListener('change', updateMasterPublicIp);
+        selectAlgorithm.addEventListener('change', updateAlgorithm);
 
         var config = document.getElementById('slave-config');
         config.innerHTML = config.innerHTML.replace(/%%js-placeholder-ip%%/g, '<span class="js-placeholder-ip"></span>');
+        config.innerHTML = config.innerHTML.replace(/%%js-placeholder-algorithm%%/g, '<span class="js-placeholder-algorithm"></span>');
         updateMasterPublicIp();
+        updateAlgorithm()
     });
 </script>
 <div class="hint" id="slave-config">
     <?=$this->partial('index/slave-config.phtml', [
         'masterPublicIp' => '%%js-placeholder-ip%%',
+        'algorithm' => '%%js-placeholder-algorithm%%',
         'secret' => $this->form->getElement('secret')->getValue(),
     ])?>
 </div>
 <p>
-    <a href="https://www.plesk.com/blog/product-technology/slave-dns-and-plesk" target="_blank"><?php echo $this->lmsg('learnMore') ?></a>
+    <a href="https://docs.plesk.com/en-US/current/administrator-guide/79004/" target="_blank"><?php echo $this->lmsg('learnMore') ?></a>
 </p>
 <?php echo $this->form ?>

--- a/plib/views/scripts/index/slave-config.phtml
+++ b/plib/views/scripts/index/slave-config.phtml
@@ -9,7 +9,7 @@ options {
 };
 
 key &quot;rndc-key-<i><?=$this->escape($this->masterPublicIp)?></i>&quot; {
-  algorithm hmac-md5;
+  algorithm <?=$this->escape($this->algorithm)?>;
   secret &quot;<b><?=$this->escape($this->secret)?></b>&quot;;
 };
 


### PR DESCRIPTION
Added support for the HMAC-SHA256 algorithm
- EXTPLESK-7788,
- "The use of HMAC-MD5 for RNDC keys is no longer recommended. The default algorithm generated by rndc-confgen is now HMAC-SHA256. [RT#42272]", https://lists.isc.org/pipermail/bind-announce/2018-January/001078.html
- https://talk.plesk.com/threads/how-to-use-algorithm-hmac-sha256-rather-than-algorithm-hmac-md5-for-slave-dns.369852